### PR TITLE
replace async with non_blocking for pytorch 1.0

### DIFF
--- a/drqa/model.py
+++ b/drqa/model.py
@@ -101,7 +101,7 @@ class DocReaderModel(object):
 
         # Transfer to GPU
         if self.opt['cuda']:
-            inputs = [Variable(e.cuda(async=True)) for e in ex[:7]]
+            inputs = [Variable(e.cuda()) for e in ex[:7]]
         else:
             inputs = [Variable(e) for e in ex[:7]]
 


### PR DESCRIPTION
this argument got renamed for pytorch 1.0:   https://pytorch.org/docs/stable/notes/cuda.html
can put it into a branch as well if you would like to keep things separate.